### PR TITLE
Update `license` format

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,5 @@
   "bugs": {
     "url": "https://github.com/Constellation/structured-source/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/Constellation/structured-source/raw/master/LICENSE.BSD"
-    }
-  ]
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
Per https://docs.npmjs.com/files/package.json#license

> Some old packages used license objects or a “licenses” property containing an array of license objects: ...
> Those styles are now deprecated. Instead, use SPDX expressions...

This is causing issues for downstream license detection. An updated release would be most appreciated as well. Thanks!